### PR TITLE
Fix capture when running in a worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "codemirror": "^6.0.1",
     "thememirror": "^2.0.1",
     "webgpu_recorder": "^1.2.0",
-    "wgsl_reflect": "file:../wgsl_reflect"
+    "wgsl_reflect": "brendan-duncan/wgsl_reflect"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/src/webgpu_inspector.js
+++ b/src/webgpu_inspector.js
@@ -251,10 +251,11 @@ export let webgpuInspector = null;
             this._captureData = null;
           }
           _sessionStorage.removeItem(webgpuInspectorCaptureFrameKey);
-          if (this._captureData) {
-            this._initCaptureData();
-          }
         }
+      }
+
+      if (this._captureData) {
+        this._initCaptureData();
       }
     }
 
@@ -1188,10 +1189,11 @@ export let webgpuInspector = null;
           }
           _sessionStorage.removeItem(webgpuInspectorCaptureFrameKey);
 
-          if (this._captureData) {
-            this._initCaptureData();
-          }
         }
+      }
+
+      if (this._captureData) {
+        this._initCaptureData();
       }
 
       if (this._captureFrameCount <= 0) {


### PR DESCRIPTION
It seems like the extension is using SessionStorage to communicate when a capture needs to be performed. However, this API is [not available in a worker](https://stackoverflow.com/questions/6179159/accessing-localstorage-from-a-webworker) so the `_initCaptureData` function would never be called.

This PR moves the `_initCaptureData` call outside of the sessionStorage check. Not sure if this is the best solution but certainly seems to work.

Also fixes a path in package.json that referenced a file outside the repo root.

Broken in at least 0.12.0:
https://github.com/user-attachments/assets/adb20311-45c8-4f81-a755-c4b41412956c

Demo after this PR:
https://github.com/user-attachments/assets/85971548-3128-4fc8-9a9d-772401cee3f7

Example of WebGPU running in a worker to test with: https://webgpu.github.io/webgpu-samples/sample/worker/


