### PR TITLE
Fix: ComputePipeline delete typo, stale objects, destroy AbortError

### DIFF
--- a/src/devtools/object_database.js
+++ b/src/devtools/object_database.js
@@ -65,12 +65,12 @@ export class ObjectDatabase {
           break;
         }
         case Actions.DeleteObject:
-          self._deleteObject(message.id);
+          self._deleteObject(message.id, true);
           break;
         case Actions.DeleteObjects: {
           const objects = message.idList;
           for (const id of objects) {
-            self._deleteObject(id);
+            self._deleteObject(id, true);
           }
           break;
         }
@@ -422,7 +422,7 @@ export class ObjectDatabase {
     }
   }
 
-  _deleteObject(id) {
+  _deleteObject(id, force) {
     const object = this.allObjects.get(id);
     if (!object) {
       return;
@@ -436,7 +436,7 @@ export class ObjectDatabase {
       self._deleteObject(obj.id);
     });
 
-    if (object.referenceCount > 0) {
+    if (!force && object.referenceCount > 0) {
       return;
     }
 
@@ -477,7 +477,7 @@ export class ObjectDatabase {
       this.pendingRenderPipelines.delete(id, object);
       this.renderPipelines.delete(id, object);
     } else if (object instanceof GPU.ComputePipeline) {
-      this.computePipelines.set(id, object);
+      this.computePipelines.delete(id, object);
       this.pendingComputePipelines.delete(id, object);
     }
 

--- a/src/utils/gpu_object_wrapper.js
+++ b/src/utils/gpu_object_wrapper.js
@@ -192,8 +192,18 @@ export class GPUObjectWrapper {
         return undefined;
       }
 
-      // Call the original method
-      const result = origMethod.call(object, ...args);
+      // Call the original method.
+      // destroy() on a buffer with pending mapAsync throws AbortError — suppress it.
+      let result;
+      try {
+        result = origMethod.call(object, ...args);
+      } catch (e) {
+        if (method === "destroy") {
+          self.onPostCall.emit(object, method, args, undefined, undefined);
+          return undefined;
+        }
+        throw e;
+      }
 
       const isCreate = GPUCreateMethods.has(method) || (self instanceof GPURenderBundleEncoder && method === "finish");
 


### PR DESCRIPTION
Three bugs in `src/devtools/object_database.js` and `src/utils/gpu_object_wrapper.js`:

### 1. ComputePipeline deletion uses `.set()` instead of `.delete()`

`object_database.js` line 480 — re-adds pipeline to map instead of removing. Compute pipeline count only goes up.

```diff
-      this.computePipelines.set(id, object);
+      this.computePipelines.delete(id, object);
```

Fixes #40

### 2. Objects deleted by runtime with references not removed from UI

When `_deleteObject` is called but `referenceCount > 0` (e.g. buffer still referenced by bind group), the early return prevents removal from type maps and suppresses `onDeleteObject`. Header count (from `map.size`) is correct but UI list retains stale entries.

Fix: add `force` parameter. Runtime-initiated deletes (`Actions.DeleteObject`/`DeleteObjects`) pass `force=true`. Cascading dependency deletes still respect `referenceCount`.

### 3. `GPUBuffer.destroy()` with pending `mapAsync` throws uncaught AbortError

`gpu_object_wrapper.js` `_wrapMethod` calls `origMethod.call()` without try/catch. When `destroy()` is called on a buffer with pending `mapAsync`, browser throws `AbortError` through the inspector wrapper.

Fix: wrap `destroy()` call in try/catch, emit post-call event, return gracefully.